### PR TITLE
[#4044] Semantic Newline Checker

### DIFF
--- a/scame/formatcheck.py
+++ b/scame/formatcheck.py
@@ -461,6 +461,13 @@ class UniversalChecker(BaseChecker):
 class AnyTextMixin:
     """Common checks for many checkers."""
 
+    def check_semantic_newline(self):
+    	"""Check that there are ., ?, or ! with a space following after.
+    	Exclude those with no new line and two full-stops."""
+    	if self.line.find(['. ', '? ', '! ']) != (['\n', '..']):
+    		self.message(
+    			0, 'Line contains a sentence without a new line.', icon='info')
+
     def check_conflicts(self, line_no, line):
         """Check that there are no merge conflict markers."""
         if line.startswith('<' * 7) or line.startswith('>' * 7):
@@ -1035,7 +1042,7 @@ class PythonChecker(BaseChecker, AnyTextMixin):
             line.encode('ascii')
         except UnicodeEncodeError as error:
             self.message(
-                line_no, 'Non-ascii characer at position %s.' % error.end,
+                line_no, 'Non-ascii character at position %s.' % error.end,
                 icon='error',
                 )
 
@@ -1243,14 +1250,14 @@ class ReStructuredTextChecker(BaseChecker, AnyTextMixin):
     def check_section_delimiter(self, line_number):
         """Checks for section delimiter.
 
-        These checkes are designed for sections delimited by top and bottom
+        These checks are designed for sections delimited by top and bottom
         markers.
 
         =======  <- top marker
         Section  <- text_line
         =======  <- bottom marker
 
-        If the section is delimted only by bottom marker, the section text
+        If the section is delimited only by bottom marker, the section text
         is considered the top marker.
 
         Section  <- top marker, text_line

--- a/scame/tests/test_restructuredtext.py
+++ b/scame/tests/test_restructuredtext.py
@@ -23,14 +23,14 @@ Text *for* first **section**.
 
 
 --------------------
-Second emtpy section
+Second empty section
 --------------------
 
 
 Third section
 ^^^^^^^^^^^^^
 
-Paragrhap for
+Paragraph for
 third section `with link<http://my.home>`_.
 
 ::
@@ -42,6 +42,13 @@ third section `with link<http://my.home>`_.
 
 | Line blocks are useful for addresses,
 | verse, and adornment-free lists.
+
+
+Newline test! No newline.
+Newline test? No newline.
+Newline test. No newline.
+Newline test has newline.
+Indeed.
 
 
 .. _section-permalink:
@@ -141,7 +148,7 @@ class TestReStructuredTextChecker(CheckerTestCase):
         self.reporter.call_count = 0
         content = (
             'Some first line\n'
-            'the second and last line witout newline')
+            'the second and last line without newline')
         checker = ReStructuredTextChecker('bogus', content, self.reporter)
         checker.check_empty_last_line(2)
         expected = [(
@@ -342,6 +349,78 @@ class TestReStructuredTextChecker(CheckerTestCase):
         expect = [(2, 'Section marker has wrong length.')]
         self.assertEqual(expect, self.reporter.messages)
         self.assertEqual(1, self.reporter.call_count)
+
+    def test_semantic_newline_fullstop(self):
+        """When a full stop is not the last character from the line, it is
+        considered a semantic newline violation and an error is reported."""
+        content = (
+            'Sentence. New sentence\n'
+            )
+        checker = ReStructuredTextChecker('bogus', content, self.reporter)
+        checker.check_semantic_newline()
+        expect = ['Newline not created after a sentence.']
+        self.assertEqual(expect, self.reporter.messages)
+        self.assertEqual(1, self.reporter.call_count)
+
+    def test_semantic_newline_fullstop_true(self):
+        """When a full stop is the last character from the line and follows the
+        semantic newline rule, an error is not reported."""
+        content = (
+            'Sentence. \n'
+            'New sentence.'
+            )
+        checker = ReStructuredTextChecker('bogus', content, self.reporter)
+        checker.check_semantic_newline()
+        self.assertEqual([], self.reporter.messages)
+        self.assertEqual(0, self.reporter.call_count)
+
+    def test_semantic_newline_questionmark(self):
+        """When a question mark is not the last character from the line, it is
+        considered a semantic newline violation and an error is reported."""
+        content = (
+            'Sentence? New sentence\n'
+            )
+        checker = ReStructuredTextChecker('bogus', content, self.reporter)
+        checker.check_semantic_newline()
+        expect = [('Newline not created after a ? sentence.')]
+        self.assertEqual(expect, self.reporter.messages)
+        self.assertEqual(1, self.reporter.call_count)
+
+    def test_semantic_newline_questionmark_true(self):
+        """When a question mark is the last character from the line and follows
+        semantic newline rule, an error is not reported."""
+        content = (
+            'Sentence? \n'
+            'New sentence\n'
+            )
+        checker = ReStructuredTextChecker('bogus', content, self.reporter)
+        checker.check_semantic_newline()
+        self.assertEqual([], self.reporter.messages)
+        self.assertEqual(0, self.reporter.call_count)
+
+    def test_semantic_newline_exclamationmark(self):
+        """When an exclamation mark is not the last character from the line, it
+        is considered a semantic newline violation and an error is reported."""
+        content = (
+            'Sentence! New sentence\n'
+            )
+        checker = ReStructuredTextChecker('bogus', content, self.reporter)
+        checker.check_semantic_newline()
+        expect = [('Newline not created after a ! sentence.')]
+        self.assertEqual(expect, self.reporter.messages)
+        self.assertEqual(1, self.reporter.call_count)
+
+    def test_semantic_newline_exclamationmark_true(self):
+        """When an exclamation mark is the last character from the line and
+        follows the semantic newline rule, an error is not reported."""
+        content = (
+            'Sentence! \n'
+            'New sentence\n'
+            )
+        checker = ReStructuredTextChecker('bogus', content, self.reporter)
+        checker.check_semantic_newline()
+        self.assertEqual([], self.reporter.messages)
+        self.assertEqual(0, self.reporter.call_count)
 
     def test_check_section_delimiter_bad_length_both_markers(self):
         content = (

--- a/scame/tests/test_restructuredtext.py
+++ b/scame/tests/test_restructuredtext.py
@@ -351,7 +351,7 @@ class TestReStructuredTextChecker(CheckerTestCase):
         self.assertEqual(1, self.reporter.call_count)
 
     def test_semantic_newline_fullstop(self):
-        """When a full stop is not the last character from the line, it is
+        """When a full stop is not the last character of the line, it is
         considered a semantic newline violation and an error is reported."""
         content = (
             'Sentence. New sentence\n'
@@ -375,7 +375,7 @@ class TestReStructuredTextChecker(CheckerTestCase):
         self.assertEqual(0, self.reporter.call_count)
 
     def test_semantic_newline_questionmark(self):
-        """When a question mark is not the last character from the line, it is
+        """When a question mark is not the last character of the line, it is
         considered a semantic newline violation and an error is reported."""
         content = (
             'Sentence? New sentence\n'
@@ -399,7 +399,7 @@ class TestReStructuredTextChecker(CheckerTestCase):
         self.assertEqual(0, self.reporter.call_count)
 
     def test_semantic_newline_exclamationmark(self):
-        """When an exclamation mark is not the last character from the line, it
+        """When an exclamation mark is not the last character of the line, it
         is considered a semantic newline violation and an error is reported."""
         content = (
             'Sentence! New sentence\n'


### PR DESCRIPTION
Scope
=====

This branch adds a semantic newline checker in scame


Changes
=======

Add the rule in formatcheck.py
Add tests in test_restructuredtext.py
Updates from the last feedback provided on https://github.com/chevah/scame/pull/2


How to try and test the changes
========================

reviewers: @adiroiban 
